### PR TITLE
[LIS-10386] Security Patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,26 @@ limitations under the License.
 
 Connectors for [Apache HBase&trade;](https://hbase.apache.org)
 
-  * [Kafka Proxy](https://github.com/apache/hbase-connectors/tree/master/kafka)
-  * [Spark](https://github.com/apache/hbase-connectors/tree/master/spark)
+* [Kafka Proxy](https://github.com/apache/hbase-connectors/tree/master/kafka)
+* [Spark](https://github.com/apache/hbase-connectors/tree/master/spark)
+
+
+# Sprout
+
+Yes, this is a clone of a public repo.  Yes, this is important and used in both listening and DFZ zones.
+
+Why Does this exist?  Simple: the hadoop ecosystem is a dependency nightmare.
+
+Keeping up with security patches is a non starter is many cases.
+
+# How to test
+
+In `./spark/pom` update this line:
+```
+<protocArtifact>com.google.protobuf:protoc:${external.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+```
+
+To Be this instead
+```
+<protocArtifact>com.google.protobuf:protoc:${external.protobuf.version}:exe:osx-x86_64</protocArtifact>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <external.protobuf.version>3.25.5</external.protobuf.version>
     <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <avro.version>1.7.7</avro.version>
+    <avro.version>1.11.4</avro.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <!--This property is for hadoops netty. HBase netty
          comes in via hbase-thirdparty hbase-shaded-netty-->

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
     <external.protobuf.version>3.25.5</external.protobuf.version>
     <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.14.0</commons-io.version>
     <avro.version>1.7.7</avro.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <!--This property is for hadoops netty. HBase netty

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <extra.enforcer.version>1.5.1</extra.enforcer.version>
     <restrict-imports.enforcer.version>0.14.0</restrict-imports.enforcer.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
-    <external.protobuf.version>2.5.0</external.protobuf.version>
+    <external.protobuf.version>3.25.5</external.protobuf.version>
     <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
     <commons-io.version>2.11.0</commons-io.version>
     <avro.version>1.7.7</avro.version>


### PR DESCRIPTION
Security version bumps for protobuf, commons-io, and avro.  

Releases version `1.0.3-sprout-emr` 